### PR TITLE
Update development and production environment configurations

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -32,6 +32,9 @@ Rails.application.configure do
   # Change to :null_store to avoid any caching.
   config.cache_store = :memory_store
 
+  # Code Reloading
+  config.cache_classes = false
+
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -21,6 +21,9 @@ Rails.application.configure do
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"
 
+  # Do not compile assets in production
+  config.assets.compile = false
+
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
   config.assume_ssl = true
 
@@ -45,6 +48,9 @@ Rails.application.configure do
 
   # Replace the default in-process memory cache store with a durable alternative.
   config.cache_store = :solid_cache_store
+
+  # Code Reloading is disabled in production
+  config.cache_classes = true
 
   # Replace the default in-process and non-durable queuing backend for Active Job.
   # config.active_job.queue_adapter = :resque


### PR DESCRIPTION
- Enabled code reloading in the development environment by setting `config.cache_classes` to false.
- Disabled asset compilation in production by setting `config.assets.compile` to false.
- Set `config.cache_classes` to true in production to improve performance.