### PR TITLE
Add webmock gem for HTTP request mocking in tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -147,4 +147,7 @@ group :test do
 
   # Cucumber for acceptance tests
   gem "cucumber-rails", require: false
+
+  # Mock HTTP requests
+  gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,9 @@ GEM
       xpath (~> 3.2)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.4)
+    crack (1.0.1)
+      bigdecimal
+      rexml
     crass (1.0.6)
     css_parser (1.21.1)
       addressable
@@ -232,6 +235,7 @@ GEM
       activesupport (>= 5.1)
       haml (>= 4.0.6)
       railties (>= 5.1)
+    hashdiff (1.2.1)
     highline (3.1.2)
       reline
     html2haml (2.3.0)
@@ -435,6 +439,7 @@ GEM
     responders (3.2.0)
       actionpack (>= 7.0)
       railties (>= 7.0)
+    rexml (3.4.4)
     rouge (4.6.1)
     rspec-core (3.13.6)
       rspec-support (~> 3.13.0)
@@ -566,6 +571,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webmock (3.26.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.8.0)
       base64
       websocket-extensions (>= 0.1.0)
@@ -643,6 +652,7 @@ DEPENDENCIES
   tzinfo-data
   view_component
   web-console
+  webmock
 
 BUNDLED WITH
    2.7.2

--- a/features/support/webmock.rb
+++ b/features/support/webmock.rb
@@ -1,0 +1,1 @@
+require "webmock/cucumber"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -14,6 +14,7 @@ require "rspec/rails"
 require "capybara/rails"
 require "capybara/rspec"
 require "view_component/test_helpers"
+require "webmock/rspec"
 
 # Check shared examples for easy to use common testing patterns for various Rails features
 Rails.root.glob("spec/support/**/*.rb").sort_by(&:to_s).each { |f| require f }


### PR DESCRIPTION
- Included the `webmock` gem in the Gemfile for mocking HTTP requests during testing.
- Updated Gemfile.lock to reflect the new dependency.
- Created a new support file for integrating webmock with Cucumber.
- Required webmock in the RSpec configuration for enhanced testing capabilities.