### PR TITLE
Add VCR gem for recording and replaying HTTP requests in tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -150,4 +150,7 @@ group :test do
 
   # Mock HTTP requests
   gem "webmock"
+
+  # Record and replay HTTP requests
+  gem "vcr"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -561,6 +561,8 @@ GEM
     unicode-emoji (4.1.0)
     uri (1.1.0)
     useragent (0.16.11)
+    vcr (6.3.1)
+      base64
     view_component (4.1.0)
       activesupport (>= 7.1.0, < 8.2)
       concurrent-ruby (~> 1)
@@ -650,6 +652,7 @@ DEPENDENCIES
   thruster
   turbo-rails
   tzinfo-data
+  vcr
   view_component
   web-console
   webmock

--- a/config/initializers/vcr.rb
+++ b/config/initializers/vcr.rb
@@ -1,0 +1,6 @@
+return unless Rails.env.test?
+
+VCR.configure do |config|
+  config.cassette_library_dir = "fixtures/vcr_cassettes"
+  config.hook_into :webmock
+end


### PR DESCRIPTION
- Included the `vcr` gem in the Gemfile to enable recording and replaying of HTTP interactions during testing.
- Updated Gemfile.lock to reflect the new dependency.
- Created a new initializer for VCR configuration, setting up the cassette library directory and integrating with webmock.